### PR TITLE
Updated HesHustle Class to extend Game

### DIFF
--- a/core/src/com/mygdx/game/HesHustle.java
+++ b/core/src/com/mygdx/game/HesHustle.java
@@ -1,31 +1,22 @@
 package com.mygdx.game;
 
-import com.badlogic.gdx.ApplicationAdapter;
-import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.Game;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.utils.ScreenUtils;
+import com.mygdx.game.screens.MainGameScreen;
 
-public class HesHustle extends ApplicationAdapter {
-	SpriteBatch batch;
-	Texture img;
-	
+public class HesHustle extends Game {
+
+	public SpriteBatch batch;
+
 	@Override
 	public void create () {
 		batch = new SpriteBatch();
-		img = new Texture("badlogic.jpg");
+		this.setScreen(new MainGameScreen(this));
 	}
 
 	@Override
 	public void render () {
-		ScreenUtils.clear(1, 0, 0, 1);
-		batch.begin();
-		batch.draw(img, 0, 0);
-		batch.end();
+		super.render();
 	}
-	
-	@Override
-	public void dispose () {
-		batch.dispose();
-		img.dispose();
-	}
+
 }

--- a/core/src/com/mygdx/game/screens/MainGameScreen.java
+++ b/core/src/com/mygdx/game/screens/MainGameScreen.java
@@ -1,0 +1,78 @@
+package com.mygdx.game.screens;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.utils.ScreenUtils;
+import com.mygdx.game.HesHustle;
+
+public class MainGameScreen implements Screen {
+
+    public static final float SPEED = 100;
+
+    Texture img;
+    float x;
+    float y;
+
+    HesHustle game;
+
+    public MainGameScreen (HesHustle game){
+        this.game = game;
+    }
+
+
+    @Override
+    public void show() {
+        img = new Texture("badlogic.jpg");
+    }
+
+    @Override
+    public void render(float delta) {
+        if (Gdx.input.isKeyPressed(Input.Keys.UP)) {
+            y += SPEED * Gdx.graphics.getDeltaTime();
+        }
+
+        if (Gdx.input.isKeyPressed(Input.Keys.DOWN)) {
+            y -= SPEED * Gdx.graphics.getDeltaTime();
+        }
+
+        if (Gdx.input.isKeyPressed(Input.Keys.LEFT)) {
+            x -= SPEED * Gdx.graphics.getDeltaTime();
+        }
+
+        if (Gdx.input.isKeyPressed(Input.Keys.RIGHT)) {
+            x += SPEED * Gdx.graphics.getDeltaTime();
+        }
+
+        ScreenUtils.clear(1, 0, 0, 1);
+        game.batch.begin();
+        game.batch.draw(img, x, y);
+        game.batch.end();
+    }
+
+    @Override
+    public void resize(int width, int height) {
+
+    }
+
+    @Override
+    public void pause() {
+
+    }
+
+    @Override
+    public void resume() {
+
+    }
+
+    @Override
+    public void hide() {
+
+    }
+
+    @Override
+    public void dispose() {
+        img.dispose();
+    }
+}


### PR DESCRIPTION
Updated HesHustle Class to extend Game instead of Application Adapter. This allows use of Screens, one of which has been created in the MainGameScreen class, in which arrow keys can be used to move a texture around the window